### PR TITLE
Add env node to config

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -21,6 +21,15 @@ module.exports = function (ctx) {
       remove: []
     },
     build: {
+      env: ctx.prod
+        ? {
+          // prod env vars here, for example:
+          // API: JSON.stringify('https://prod.api.com')
+        }
+        : {
+          // dev env vars here, for example:
+          // API: JSON.stringify('https://dev.api.com')
+        },
       scopeHoisting: true,
       vueRouterMode: 'history',
       // gzip: true,


### PR DESCRIPTION
Added the `env` node to config file with example of how to add vars.

Although Razvan's example in the documentation tests for .dev first, I think it's safer to test for .prod first. That way, we're explicit that we only use production values when we are absolutely sure we're in prod, and then fall through to the dev.